### PR TITLE
Moved configuration settings to a config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # MacDash
+
+## Getting Started
+```
+pip install -r requirements.txt
+```
+
+Make a copy of `example_config.py` and change the filename to `config.py`.
+
+```
+cp example_config.py config.py
+```
+
+Set values for the following keys:
+```
+JSS_RESOURCE_BASE_URL
+JSS_USERNAME
+JSS_PASSWORD
+```


### PR DESCRIPTION
 Currently there is an example_config.py and that should be copied and renamed to config.py, which should not be picked up due to the entry in .gitignore. Created a jss-request function that takes the endpoint for the JSS API that is being called.

@cshepp1211 Let me know what you think about this approach. it makes sense to have a single function to handle api calls. Just in case the JSS API ever changes how you haven't to interact it with it. You wouldn't want to have to change every single line. We'll eventually want to change the actual endpoints since those are specific to your JSS.

The config file should be where anything specific to your or my environment lives. 
